### PR TITLE
feat: record total time and split times on entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ docs/
 - **Single hook for data access:** `useTrainingData()` provides exercises, liftEntries, loading/error state, and mutation functions (addEntry, updateEntry, deleteEntry, deleteExerciseById). All screens consume this hook directly.
 - **No auth:** v1 is single-user. Supabase RLS is disabled.
 - **All weights are in kilograms (KG).** No unit conversion exists.
+- **All times are stored as seconds.** `src/lib/duration.ts` parses the `mm:ss` / `h:mm:ss` / plain-seconds forms the UI accepts and formats seconds back for display.
 
 ## Design System (Mono Theme)
 
@@ -72,7 +73,7 @@ Key design rules from the spec:
 Two Supabase tables (see `docs/supabase_schema.sql`):
 
 - **exercises:** `id` (uuid), `name` (unique text), `created_at`
-- **lift_entries:** `id` (uuid), `exercise_id` (FK), `weight_kg`, `reps`, `performed_at`, `notes`, `created_at`
+- **lift_entries:** `id` (uuid), `exercise_id` (FK), `weight_kg`, `reps`, `performed_at`, `notes`, `duration_seconds` (nullable total time), `split_seconds` (nullable jsonb array of split times), `created_at`
 - **exercise_stats** (view): aggregates max weight, last session, entry count per exercise
 
 TypeScript domain types use camelCase (mapped from snake_case DB columns in `trainingRepository.ts`).

--- a/docs/supabase_schema.sql
+++ b/docs/supabase_schema.sql
@@ -16,8 +16,17 @@ create table if not exists lift_entries (
   reps int not null check (reps > 0),
   performed_at timestamptz not null,
   notes text,
+  -- Total time for the entry, in seconds. Null when the entry was untimed.
+  duration_seconds numeric(8,2) check (duration_seconds is null or duration_seconds > 0),
+  -- Ordered split times, in seconds, e.g. [92.5, 88, 95].
+  split_seconds jsonb,
   created_at timestamptz not null default now()
 );
+
+-- Existing databases: add the timing columns in place.
+alter table lift_entries
+  add column if not exists duration_seconds numeric(8,2),
+  add column if not exists split_seconds jsonb;
 
 create index if not exists idx_lift_entries_exercise_id on lift_entries(exercise_id);
 create index if not exists idx_lift_entries_performed_at on lift_entries(performed_at desc);

--- a/src/components/AddLiftEntryModal.tsx
+++ b/src/components/AddLiftEntryModal.tsx
@@ -10,7 +10,13 @@ import {
   View,
 } from "react-native";
 
+import { parseDurationToSeconds } from "../lib/duration";
 import { monoColors } from "../theme/mono";
+import {
+  parseSplitInputs,
+  SplitTimesInput,
+  TIME_KEYBOARD,
+} from "./SplitTimesInput";
 
 type AddLiftEntryModalProps = {
   visible: boolean;
@@ -20,6 +26,8 @@ type AddLiftEntryModalProps = {
     weightKg: number;
     reps: number;
     notes: string;
+    durationSeconds: number | null;
+    splitSeconds: number[];
   }) => Promise<void>;
   // When provided, the exercise field is locked to this value and shown as a label.
   lockedExerciseName?: string;
@@ -37,6 +45,9 @@ export const AddLiftEntryModal = ({
   const [weightKg, setWeightKg] = useState("");
   const [reps, setReps] = useState("");
   const [notes, setNotes] = useState("");
+  const [time, setTime] = useState("");
+  const [splits, setSplits] = useState<string[]>([]);
+  const [formError, setFormError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [keyboardHeight, setKeyboardHeight] = useState(0);
   const [showOneRmHint, setShowOneRmHint] = useState(false);
@@ -65,6 +76,9 @@ export const AddLiftEntryModal = ({
     setWeightKg("");
     setReps("");
     setNotes("");
+    setTime("");
+    setSplits([]);
+    setFormError(null);
     setShowOneRmHint(false);
   };
 
@@ -85,9 +99,26 @@ export const AddLiftEntryModal = ({
       !Number.isFinite(parsedReps) ||
       parsedReps <= 0
     ) {
+      setFormError("Enter an exercise, a weight and a rep count.");
       return;
     }
 
+    let durationSeconds: number | null = null;
+    if (time.trim()) {
+      durationSeconds = parseDurationToSeconds(time);
+      if (durationSeconds === null) {
+        setFormError("Time must look like 45, 2:30 or 1:05:00.");
+        return;
+      }
+    }
+
+    const splitSeconds = parseSplitInputs(splits);
+    if (splitSeconds === null) {
+      setFormError("Splits must look like 45, 2:30 or 1:05:00.");
+      return;
+    }
+
+    setFormError(null);
     setIsSubmitting(true);
     try {
       await onSubmit({
@@ -95,6 +126,8 @@ export const AddLiftEntryModal = ({
         weightKg: parsedWeight,
         reps: parsedReps,
         notes,
+        durationSeconds,
+        splitSeconds,
       });
       resetForm();
     } finally {
@@ -128,7 +161,7 @@ export const AddLiftEntryModal = ({
               style={{ fontFamily: "Inter_800ExtraBold", fontSize: 24 }}
               className="text-mono-primary"
             >
-              Add Lift Entry
+              Add Entry
             </Text>
             <Pressable
               onPress={() => setShowOneRmHint((current) => !current)}
@@ -220,6 +253,15 @@ export const AddLiftEntryModal = ({
               />
             </View>
             <TextInput
+              value={time}
+              onChangeText={setTime}
+              placeholder="Time — mm:ss (optional)"
+              keyboardType={TIME_KEYBOARD}
+              placeholderTextColor={monoColors.secondary}
+              className="rounded-sm bg-mono-surfaceContainer px-3 py-3 text-mono-primary"
+              style={{ fontFamily: "Inter_500Medium" }}
+            />
+            <TextInput
               value={notes}
               onChangeText={setNotes}
               placeholder="Notes (optional)"
@@ -229,12 +271,17 @@ export const AddLiftEntryModal = ({
             />
           </View>
 
-          {error ? (
+          {/* Split times */}
+          <View className="mt-5">
+            <SplitTimesInput splits={splits} onChange={setSplits} />
+          </View>
+
+          {formError || error ? (
             <Text
               style={{ fontFamily: "Inter_500Medium" }}
               className="mt-3 text-mono-secondary"
             >
-              {error}
+              {formError ?? error}
             </Text>
           ) : null}
 

--- a/src/components/SplitTimesInput.tsx
+++ b/src/components/SplitTimesInput.tsx
@@ -1,0 +1,155 @@
+import { useMemo } from "react";
+import { Platform, Pressable, Text, TextInput, View } from "react-native";
+
+import { formatDuration, parseDurationToSeconds } from "../lib/duration";
+import { monoColors } from "../theme/mono";
+
+// Colon-friendly keypad on iOS; Android's default keyboard already has one.
+export const TIME_KEYBOARD =
+  Platform.OS === "ios" ? "numbers-and-punctuation" : "default";
+
+type SplitTimesInputProps = {
+  /** Raw, user-typed split values. Parsing happens on save. */
+  splits: string[];
+  onChange: (splits: string[]) => void;
+};
+
+export const SplitTimesInput = ({ splits, onChange }: SplitTimesInputProps) => {
+  // Running total shown under the splits, so the user can sanity-check them.
+  const splitsTotal = useMemo(() => {
+    const filled = splits.filter((split) => split.trim());
+    if (filled.length === 0) {
+      return null;
+    }
+
+    const parsed = filled.map(parseDurationToSeconds);
+    if (parsed.some((seconds) => seconds === null)) {
+      return null;
+    }
+
+    return (parsed as number[]).reduce((total, seconds) => total + seconds, 0);
+  }, [splits]);
+
+  return (
+    <View className="rounded-sm bg-mono-surface px-3 py-3">
+      <View className="flex-row items-center justify-between">
+        <Text
+          style={{
+            fontFamily: "Inter_700Bold",
+            fontSize: 11,
+            letterSpacing: 0.5,
+            textTransform: "uppercase",
+          }}
+          className="text-mono-secondary"
+        >
+          Split Times
+        </Text>
+        <Pressable
+          onPress={() => onChange([...splits, ""])}
+          accessibilityRole="button"
+          accessibilityLabel="Add a split time"
+          hitSlop={8}
+          className="rounded-sm bg-mono-surfaceContainer px-3 py-1"
+        >
+          <Text
+            style={{ fontFamily: "Inter_700Bold", fontSize: 12 }}
+            className="text-mono-primary"
+          >
+            + Add split
+          </Text>
+        </Pressable>
+      </View>
+
+      {splits.length === 0 ? (
+        <Text
+          style={{ fontFamily: "Inter_400Regular", fontSize: 13 }}
+          className="mt-2 text-mono-secondary"
+        >
+          Add a split for each round, lap or interval.
+        </Text>
+      ) : (
+        <View className="mt-3 gap-2">
+          {splits.map((split, index) => (
+            <View key={index} className="flex-row items-center gap-2">
+              <Text
+                style={{
+                  fontFamily: "Inter_700Bold",
+                  fontSize: 11,
+                  letterSpacing: 0.5,
+                }}
+                className="w-6 text-mono-secondary"
+              >
+                {index + 1}
+              </Text>
+              <TextInput
+                value={split}
+                onChangeText={(value) =>
+                  onChange(
+                    splits.map((current, currentIndex) =>
+                      currentIndex === index ? value : current,
+                    ),
+                  )
+                }
+                placeholder="mm:ss"
+                keyboardType={TIME_KEYBOARD}
+                placeholderTextColor={monoColors.secondary}
+                className="flex-1 rounded-sm bg-mono-surfaceContainer px-3 py-2 text-mono-primary"
+                style={{ fontFamily: "Inter_500Medium" }}
+              />
+              <Pressable
+                onPress={() =>
+                  onChange(
+                    splits.filter((_, currentIndex) => currentIndex !== index),
+                  )
+                }
+                accessibilityRole="button"
+                accessibilityLabel={`Remove split ${index + 1}`}
+                hitSlop={8}
+                className="h-8 w-8 items-center justify-center rounded-sm bg-mono-surfaceContainer"
+              >
+                <Text
+                  style={{ fontFamily: "Inter_700Bold", fontSize: 14 }}
+                  className="text-mono-secondary"
+                >
+                  ×
+                </Text>
+              </Pressable>
+            </View>
+          ))}
+
+          {splitsTotal ? (
+            <Text
+              style={{ fontFamily: "Inter_500Medium", fontSize: 12 }}
+              className="mt-1 text-mono-secondary"
+            >
+              Splits total {formatDuration(splitsTotal)}
+            </Text>
+          ) : null}
+        </View>
+      )}
+    </View>
+  );
+};
+
+/**
+ * Parses the raw split inputs, skipping blanks.
+ * Returns null if any non-blank value is not a valid duration.
+ */
+export const parseSplitInputs = (splits: string[]): number[] | null => {
+  const parsed: number[] = [];
+
+  for (const split of splits) {
+    if (!split.trim()) {
+      continue;
+    }
+
+    const seconds = parseDurationToSeconds(split);
+    if (seconds === null) {
+      return null;
+    }
+
+    parsed.push(seconds);
+  }
+
+  return parsed;
+};

--- a/src/lib/duration.ts
+++ b/src/lib/duration.ts
@@ -1,0 +1,54 @@
+// Durations are stored as seconds. The UI accepts "45", "mm:ss" or "h:mm:ss".
+
+const NUMERIC_PART = /^\d*\.?\d+$/;
+
+/**
+ * Parses a user-typed duration into seconds.
+ * Returns null when the value is empty or not a valid positive duration.
+ */
+export const parseDurationToSeconds = (raw: string): number | null => {
+  const value = raw.trim();
+  if (!value) {
+    return null;
+  }
+
+  const parts = value.split(":");
+  if (parts.length > 3) {
+    return null;
+  }
+
+  let seconds = 0;
+  for (let index = 0; index < parts.length; index += 1) {
+    const part = parts[index].trim();
+    if (!NUMERIC_PART.test(part)) {
+      return null;
+    }
+
+    const parsed = Number(part);
+    // In mm:ss / h:mm:ss form every segment after the first is a 0-59 unit.
+    if (parts.length > 1 && index > 0 && parsed >= 60) {
+      return null;
+    }
+
+    seconds = seconds * 60 + parsed;
+  }
+
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return null;
+  }
+
+  return Math.round(seconds * 100) / 100;
+};
+
+/** Formats seconds as m:ss, or h:mm:ss once the duration passes an hour. */
+export const formatDuration = (totalSeconds: number): string => {
+  const rounded = Math.round(totalSeconds);
+  const hours = Math.floor(rounded / 3600);
+  const minutes = Math.floor((rounded % 3600) / 60);
+  const seconds = rounded % 60;
+  const pad = (value: number) => String(value).padStart(2, "0");
+
+  return hours > 0
+    ? `${hours}:${pad(minutes)}:${pad(seconds)}`
+    : `${minutes}:${pad(seconds)}`;
+};

--- a/src/lib/trainingRepository.ts
+++ b/src/lib/trainingRepository.ts
@@ -29,6 +29,15 @@ const mapExerciseRow = (row: any): Exercise => ({
   createdAt: parseRowDate(row.created_at),
 });
 
+const mapSplitSeconds = (value: any): number[] | null => {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const splits = value.map(Number).filter((split) => Number.isFinite(split));
+  return splits.length > 0 ? splits : null;
+};
+
 const mapLiftRow = (row: any): LiftEntry => ({
   id: String(row.id),
   exerciseId: String(row.exercise_id),
@@ -36,6 +45,11 @@ const mapLiftRow = (row: any): LiftEntry => ({
   reps: Number(row.reps),
   performedAt: parseRowDate(row.performed_at),
   notes: row.notes ?? null,
+  durationSeconds:
+    row.duration_seconds === null || row.duration_seconds === undefined
+      ? null
+      : Number(row.duration_seconds),
+  splitSeconds: mapSplitSeconds(row.split_seconds),
 });
 
 const readCache = async (): Promise<CachePayload | null> => {
@@ -173,6 +187,8 @@ export const addLiftEntry = async (input: AddLiftEntryInput): Promise<void> => {
         reps: input.reps,
         performed_at: input.performedAt,
         notes: input.notes ?? null,
+        duration_seconds: input.durationSeconds ?? null,
+        split_seconds: input.splitSeconds?.length ? input.splitSeconds : null,
       });
 
       if (insertLiftResult.error) {
@@ -198,6 +214,8 @@ export const addLiftEntry = async (input: AddLiftEntryInput): Promise<void> => {
     reps: input.reps,
     performedAt: input.performedAt,
     notes: input.notes ?? null,
+    durationSeconds: input.durationSeconds ?? null,
+    splitSeconds: input.splitSeconds?.length ? input.splitSeconds : null,
   };
 
   await writeCache({
@@ -218,6 +236,8 @@ export const updateLiftEntry = async (
           reps: input.reps,
           performed_at: input.performedAt,
           notes: input.notes ?? null,
+          duration_seconds: input.durationSeconds ?? null,
+          split_seconds: input.splitSeconds?.length ? input.splitSeconds : null,
         })
         .eq("id", input.id);
 
@@ -240,6 +260,8 @@ export const updateLiftEntry = async (
           reps: input.reps,
           performedAt: input.performedAt,
           notes: input.notes ?? null,
+          durationSeconds: input.durationSeconds ?? null,
+          splitSeconds: input.splitSeconds?.length ? input.splitSeconds : null,
         }
       : entry,
   );

--- a/src/screens/ExerciseDetailScreen.tsx
+++ b/src/screens/ExerciseDetailScreen.tsx
@@ -4,6 +4,7 @@ import {
   FlatList,
   Modal,
   Pressable,
+  ScrollView,
   Text,
   TextInput,
   View,
@@ -13,8 +14,14 @@ import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import type { HistoryStackParamList } from "../navigation/AppNavigator";
 import type { LiftEntry } from "../types/domain";
 import { useTrainingData } from "../hooks/useTrainingData";
+import { formatDuration, parseDurationToSeconds } from "../lib/duration";
 import { monoColors } from "../theme/mono";
 import { AddLiftEntryModal } from "../components/AddLiftEntryModal";
+import {
+  parseSplitInputs,
+  SplitTimesInput,
+  TIME_KEYBOARD,
+} from "../components/SplitTimesInput";
 
 type Props = NativeStackScreenProps<HistoryStackParamList, "ExerciseDetail">;
 
@@ -59,6 +66,9 @@ export const ExerciseDetailScreen = ({ route, navigation }: Props) => {
   const [editWeightKg, setEditWeightKg] = useState("");
   const [editReps, setEditReps] = useState("");
   const [editNotes, setEditNotes] = useState("");
+  const [editTime, setEditTime] = useState("");
+  const [editSplits, setEditSplits] = useState<string[]>([]);
+  const [editError, setEditError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   // Add modal state
@@ -70,6 +80,8 @@ export const ExerciseDetailScreen = ({ route, navigation }: Props) => {
       weightKg: number;
       reps: number;
       notes: string;
+      durationSeconds: number | null;
+      splitSeconds: number[];
     }) => {
       await addEntry({
         exerciseName: values.exerciseName,
@@ -77,6 +89,8 @@ export const ExerciseDetailScreen = ({ route, navigation }: Props) => {
         reps: values.reps,
         performedAt: new Date().toISOString(),
         notes: values.notes,
+        durationSeconds: values.durationSeconds,
+        splitSeconds: values.splitSeconds,
       });
       setIsAddModalOpen(false);
     },
@@ -93,6 +107,13 @@ export const ExerciseDetailScreen = ({ route, navigation }: Props) => {
     setEditWeightKg(String(selectedEntry.weightKg));
     setEditReps(String(selectedEntry.reps));
     setEditNotes(selectedEntry.notes ?? "");
+    setEditTime(
+      selectedEntry.durationSeconds
+        ? formatDuration(selectedEntry.durationSeconds)
+        : "",
+    );
+    setEditSplits((selectedEntry.splitSeconds ?? []).map(formatDuration));
+    setEditError(null);
     setIsActionMenuOpen(false);
     setIsEditModalOpen(true);
   }, [selectedEntry]);
@@ -109,9 +130,26 @@ export const ExerciseDetailScreen = ({ route, navigation }: Props) => {
       !Number.isFinite(parsedReps) ||
       parsedReps <= 0
     ) {
+      setEditError("Enter a weight and a rep count.");
       return;
     }
 
+    let durationSeconds: number | null = null;
+    if (editTime.trim()) {
+      durationSeconds = parseDurationToSeconds(editTime);
+      if (durationSeconds === null) {
+        setEditError("Time must look like 45, 2:30 or 1:05:00.");
+        return;
+      }
+    }
+
+    const splitSeconds = parseSplitInputs(editSplits);
+    if (splitSeconds === null) {
+      setEditError("Splits must look like 45, 2:30 or 1:05:00.");
+      return;
+    }
+
+    setEditError(null);
     setIsSubmitting(true);
     try {
       await updateEntry({
@@ -120,13 +158,23 @@ export const ExerciseDetailScreen = ({ route, navigation }: Props) => {
         reps: parsedReps,
         performedAt: selectedEntry.performedAt,
         notes: editNotes || undefined,
+        durationSeconds,
+        splitSeconds,
       });
       setIsEditModalOpen(false);
       setSelectedEntry(null);
     } finally {
       setIsSubmitting(false);
     }
-  }, [selectedEntry, editWeightKg, editReps, editNotes, updateEntry]);
+  }, [
+    selectedEntry,
+    editWeightKg,
+    editReps,
+    editNotes,
+    editTime,
+    editSplits,
+    updateEntry,
+  ]);
 
   const confirmDeleteEntry = useCallback(() => {
     if (!selectedEntry) return;
@@ -174,7 +222,7 @@ export const ExerciseDetailScreen = ({ route, navigation }: Props) => {
         className="rounded-sm bg-mono-surface px-3 py-3"
       >
         <View className="flex-row items-start justify-between">
-          <View>
+          <View className="flex-1 pr-3">
             <View className="flex-row items-baseline gap-1">
               <Text
                 style={{ fontFamily: "Inter_800ExtraBold", fontSize: 22 }}
@@ -194,7 +242,18 @@ export const ExerciseDetailScreen = ({ route, navigation }: Props) => {
               className="mt-0.5 text-mono-secondary"
             >
               {item.reps} {item.reps === 1 ? "rep" : "reps"}
+              {item.durationSeconds
+                ? ` · ${formatDuration(item.durationSeconds)}`
+                : ""}
             </Text>
+            {item.splitSeconds?.length ? (
+              <Text
+                style={{ fontFamily: "Inter_500Medium", fontSize: 11 }}
+                className="mt-1 text-mono-secondary"
+              >
+                Splits {item.splitSeconds.map(formatDuration).join(" / ")}
+              </Text>
+            ) : null}
           </View>
           <View className="items-end">
             <Text
@@ -360,12 +419,23 @@ export const ExerciseDetailScreen = ({ route, navigation }: Props) => {
         onRequestClose={() => setIsEditModalOpen(false)}
       >
         <View className="flex-1 justify-end bg-black/25">
-          <View className="rounded-t-xl bg-mono-background px-4 pb-8 pt-5">
+          <ScrollView
+            style={{ maxHeight: "85%" }}
+            contentContainerStyle={{
+              paddingHorizontal: 16,
+              paddingBottom: 32,
+              paddingTop: 20,
+            }}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+            alwaysBounceVertical={false}
+            className="rounded-t-xl bg-mono-background"
+          >
             <Text
               style={{ fontFamily: "Inter_800ExtraBold", fontSize: 24 }}
               className="text-mono-primary"
             >
-              Edit Lift Entry
+              Edit Entry
             </Text>
 
             <View className="mt-2 rounded-sm bg-mono-surfaceContainerLow px-3 py-2">
@@ -399,6 +469,15 @@ export const ExerciseDetailScreen = ({ route, navigation }: Props) => {
                 />
               </View>
               <TextInput
+                value={editTime}
+                onChangeText={setEditTime}
+                placeholder="Time — mm:ss (optional)"
+                keyboardType={TIME_KEYBOARD}
+                placeholderTextColor={monoColors.secondary}
+                className="rounded-sm bg-mono-surfaceContainer px-3 py-3 text-mono-primary"
+                style={{ fontFamily: "Inter_500Medium" }}
+              />
+              <TextInput
                 value={editNotes}
                 onChangeText={setEditNotes}
                 placeholder="Notes (optional)"
@@ -407,6 +486,19 @@ export const ExerciseDetailScreen = ({ route, navigation }: Props) => {
                 style={{ fontFamily: "Inter_500Medium" }}
               />
             </View>
+
+            <View className="mt-5">
+              <SplitTimesInput splits={editSplits} onChange={setEditSplits} />
+            </View>
+
+            {editError ? (
+              <Text
+                style={{ fontFamily: "Inter_500Medium" }}
+                className="mt-3 text-mono-secondary"
+              >
+                {editError}
+              </Text>
+            ) : null}
 
             <View className="mt-5 flex-row gap-3">
               <Pressable
@@ -436,7 +528,7 @@ export const ExerciseDetailScreen = ({ route, navigation }: Props) => {
                 </Text>
               </Pressable>
             </View>
-          </View>
+          </ScrollView>
         </View>
       </Modal>
     </View>

--- a/src/screens/HistoryScreen.tsx
+++ b/src/screens/HistoryScreen.tsx
@@ -82,6 +82,8 @@ export const HistoryScreen = () => {
     weightKg: number;
     reps: number;
     notes: string;
+    durationSeconds: number | null;
+    splitSeconds: number[];
   }) => {
     await addEntry({
       exerciseName: values.exerciseName,
@@ -89,6 +91,8 @@ export const HistoryScreen = () => {
       reps: values.reps,
       performedAt: new Date().toISOString(),
       notes: values.notes,
+      durationSeconds: values.durationSeconds,
+      splitSeconds: values.splitSeconds,
     });
     setIsModalOpen(false);
   };

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -11,6 +11,10 @@ export type LiftEntry = {
   reps: number;
   performedAt: string;
   notes?: string | null;
+  /** Total time for the entry, in seconds. */
+  durationSeconds?: number | null;
+  /** Individual split times, in seconds, in the order they were recorded. */
+  splitSeconds?: number[] | null;
 };
 
 export type AddLiftEntryInput = {
@@ -19,6 +23,8 @@ export type AddLiftEntryInput = {
   reps: number;
   performedAt: string;
   notes?: string;
+  durationSeconds?: number | null;
+  splitSeconds?: number[] | null;
 };
 
 export type UpdateLiftEntryInput = {
@@ -27,4 +33,6 @@ export type UpdateLiftEntryInput = {
   reps: number;
   performedAt: string;
   notes?: string;
+  durationSeconds?: number | null;
+  splitSeconds?: number[] | null;
 };


### PR DESCRIPTION
Rename the add/edit modal headings to "Add Entry"/"Edit Entry" and add an optional time box plus a repeatable split-times field to both.

Times are entered as 45, 2:30 or 1:05:00 and stored as seconds. Splits are numbered, individually removable, and show a running total. Malformed values are rejected inline rather than saved.

The edit modal carries time and splits through, since updates write every column and would otherwise wipe them.

Persistence covers both the Supabase and AsyncStorage paths; the schema gains nullable duration_seconds and split_seconds columns with an in-place migration for existing databases.