### PR TITLE
feat: add countdown timer alongside the stopwatch

### DIFF
--- a/src/screens/TimersScreen.tsx
+++ b/src/screens/TimersScreen.tsx
@@ -1,330 +1,66 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { Pressable, ScrollView, Text, View } from "react-native";
+import { useState } from "react";
+import { Pressable, Text, View } from "react-native";
 
-type Split = {
-  index: number;
-  /** Elapsed time on the stopwatch when the split was taken. */
-  totalMs: number;
-  /** Time since the previous split. */
-  lapMs: number;
-};
+import { StopwatchPanel } from "./timers/StopwatchPanel";
+import { TimerPanel } from "./timers/TimerPanel";
 
-const pad = (value: number, length = 2) => String(value).padStart(length, "0");
+type TimersTab = "stopwatch" | "timer";
 
-const formatDuration = (ms: number) => {
-  const totalSeconds = Math.floor(ms / 1000);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  const centiseconds = Math.floor((ms % 1000) / 10);
-
-  return {
-    clock: `${pad(minutes)}:${pad(seconds)}`,
-    centiseconds: pad(centiseconds),
-  };
-};
-
-const formatFull = (ms: number) => {
-  const { clock, centiseconds } = formatDuration(ms);
-  return `${clock}.${centiseconds}`;
-};
+const TABS: { key: TimersTab; label: string }[] = [
+  { key: "stopwatch", label: "STOPWATCH" },
+  { key: "timer", label: "TIMER" },
+];
 
 export const TimersScreen = () => {
-  const [elapsedMs, setElapsedMs] = useState(0);
-  const [isRunning, setIsRunning] = useState(false);
-  const [splits, setSplits] = useState<Split[]>([]);
-
-  // Wall-clock anchors so the timer stays accurate even if the interval drifts.
-  const startedAtRef = useRef(0);
-  const accumulatedRef = useRef(0);
-
-  useEffect(() => {
-    if (!isRunning) {
-      return;
-    }
-
-    const tick = () => {
-      setElapsedMs(accumulatedRef.current + (Date.now() - startedAtRef.current));
-    };
-
-    tick();
-    const interval = setInterval(tick, 50);
-
-    return () => clearInterval(interval);
-  }, [isRunning]);
-
-  const handleStartStop = () => {
-    if (isRunning) {
-      accumulatedRef.current += Date.now() - startedAtRef.current;
-      setElapsedMs(accumulatedRef.current);
-      setIsRunning(false);
-      return;
-    }
-
-    startedAtRef.current = Date.now();
-    setIsRunning(true);
-  };
-
-  const handleSplit = () => {
-    const totalMs = isRunning
-      ? accumulatedRef.current + (Date.now() - startedAtRef.current)
-      : elapsedMs;
-    const previousTotal = splits.length > 0 ? splits[0].totalMs : 0;
-
-    setSplits((current) => [
-      {
-        index: current.length + 1,
-        totalMs,
-        lapMs: totalMs - previousTotal,
-      },
-      ...current,
-    ]);
-  };
-
-  const handleReset = () => {
-    accumulatedRef.current = 0;
-    startedAtRef.current = 0;
-    setIsRunning(false);
-    setElapsedMs(0);
-    setSplits([]);
-  };
-
-  const display = useMemo(() => formatDuration(elapsedMs), [elapsedMs]);
-
-  const canSplit = isRunning || elapsedMs > 0;
-  const canReset = !isRunning && (elapsedMs > 0 || splits.length > 0);
-
-  const fastestSplit = useMemo(() => {
-    if (splits.length < 2) {
-      return null;
-    }
-    return splits.reduce((best, split) =>
-      split.lapMs < best.lapMs ? split : best,
-    );
-  }, [splits]);
-
-  const slowestSplit = useMemo(() => {
-    if (splits.length < 2) {
-      return null;
-    }
-    return splits.reduce((worst, split) =>
-      split.lapMs > worst.lapMs ? split : worst,
-    );
-  }, [splits]);
+  const [activeTab, setActiveTab] = useState<TimersTab>("stopwatch");
 
   return (
     <View className="flex-1 bg-mono-background px-5 pt-2">
-      {/* Stopwatch readout */}
-      <View className="rounded-sm bg-mono-surface px-4 py-6">
-        <Text
-          style={{
-            fontFamily: "Inter_700Bold",
-            fontSize: 11,
-            letterSpacing: 0.8,
-          }}
-          className="text-mono-secondary"
-        >
-          STOPWATCH
-        </Text>
+      {/* Tabs */}
+      <View className="flex-row gap-2 rounded-sm bg-mono-surface p-1">
+        {TABS.map((tab) => {
+          const isActive = activeTab === tab.key;
 
-        <View className="mt-1 flex-row items-baseline">
-          <Text
-            style={{
-              fontFamily: "Inter_900Black",
-              fontSize: 64,
-              letterSpacing: -2.5,
-              fontVariant: ["tabular-nums"],
-            }}
-            className="text-mono-primary"
-          >
-            {display.clock}
-          </Text>
-          <Text
-            style={{
-              fontFamily: "Inter_800ExtraBold",
-              fontSize: 28,
-              letterSpacing: -0.8,
-              fontVariant: ["tabular-nums"],
-            }}
-            className="ml-1 text-mono-secondary"
-          >
-            .{display.centiseconds}
-          </Text>
-        </View>
-
-        <Text
-          style={{
-            fontFamily: "Inter_700Bold",
-            fontSize: 10,
-            letterSpacing: 1.2,
-          }}
-          className="text-mono-secondary"
-        >
-          {isRunning ? "RUNNING" : elapsedMs > 0 ? "PAUSED" : "READY"}
-        </Text>
-      </View>
-
-      {/* Controls */}
-      <View className="mt-3 flex-row gap-3">
-        <Pressable
-          onPress={handleStartStop}
-          className={`flex-1 items-center rounded-sm py-4 ${
-            isRunning ? "bg-mono-primaryContainer" : "bg-mono-primary"
-          }`}
-        >
-          <Text
-            style={{
-              fontFamily: "Inter_700Bold",
-              fontSize: 12,
-              letterSpacing: 1.2,
-            }}
-            className="text-mono-background"
-          >
-            {isRunning ? "STOP" : elapsedMs > 0 ? "RESUME" : "START"}
-          </Text>
-        </Pressable>
-
-        <Pressable
-          onPress={handleSplit}
-          disabled={!canSplit}
-          className={`flex-1 items-center rounded-sm py-4 ${
-            canSplit ? "bg-mono-surfaceContainer" : "bg-mono-surface"
-          }`}
-        >
-          <Text
-            style={{
-              fontFamily: "Inter_700Bold",
-              fontSize: 12,
-              letterSpacing: 1.2,
-            }}
-            className={canSplit ? "text-mono-primary" : "text-mono-secondary"}
-          >
-            SPLIT
-          </Text>
-        </Pressable>
-
-        <Pressable
-          onPress={handleReset}
-          disabled={!canReset}
-          className={`flex-1 items-center rounded-sm py-4 ${
-            canReset ? "bg-mono-surfaceContainer" : "bg-mono-surface"
-          }`}
-        >
-          <Text
-            style={{
-              fontFamily: "Inter_700Bold",
-              fontSize: 12,
-              letterSpacing: 1.2,
-            }}
-            className={canReset ? "text-mono-primary" : "text-mono-secondary"}
-          >
-            RESET
-          </Text>
-        </Pressable>
-      </View>
-
-      {/* Splits */}
-      <Text
-        style={{
-          fontFamily: "Inter_700Bold",
-          fontSize: 11,
-          letterSpacing: 0.8,
-        }}
-        className="mt-6 text-mono-secondary"
-      >
-        SPLITS ({splits.length})
-      </Text>
-
-      {splits.length === 0 ? (
-        <View className="mt-3 rounded-sm bg-mono-surface px-4 py-6">
-          <Text
-            style={{ fontFamily: "Inter_500Medium", fontSize: 13 }}
-            className="text-mono-secondary"
-          >
-            Start the stopwatch and tap SPLIT to record a lap. Each split stores
-            the lap time and the total elapsed time.
-          </Text>
-        </View>
-      ) : (
-        <ScrollView
-          className="mt-3"
-          contentContainerStyle={{ paddingBottom: 24, gap: 2 }}
-          showsVerticalScrollIndicator={false}
-        >
-          {splits.map((split) => {
-            const isFastest = fastestSplit?.index === split.index;
-            const isSlowest = slowestSplit?.index === split.index;
-
-            return (
-              <View
-                key={split.index}
-                className={`flex-row items-center rounded-sm px-4 py-3 ${
-                  isFastest ? "bg-mono-surfaceContainer" : "bg-mono-surface"
-                }`}
+          return (
+            <Pressable
+              key={tab.key}
+              onPress={() => setActiveTab(tab.key)}
+              className={`flex-1 items-center rounded-sm py-3 ${
+                isActive ? "bg-mono-primary" : "bg-transparent"
+              }`}
+            >
+              <Text
+                style={{
+                  fontFamily: "Inter_700Bold",
+                  fontSize: 12,
+                  letterSpacing: 1.2,
+                }}
+                className={
+                  isActive ? "text-mono-background" : "text-mono-secondary"
+                }
               >
-                <Text
-                  style={{
-                    fontFamily: "Inter_700Bold",
-                    fontSize: 11,
-                    letterSpacing: 0.6,
-                  }}
-                  className="w-10 text-mono-secondary"
-                >
-                  {pad(split.index)}
-                </Text>
+                {tab.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
 
-                <View className="flex-1">
-                  <Text
-                    style={{
-                      fontFamily: "Inter_900Black",
-                      fontSize: 22,
-                      letterSpacing: -0.5,
-                      fontVariant: ["tabular-nums"],
-                    }}
-                    className="text-mono-primary"
-                  >
-                    {formatFull(split.lapMs)}
-                  </Text>
-                  {(isFastest || isSlowest) && (
-                    <Text
-                      style={{
-                        fontFamily: "Inter_700Bold",
-                        fontSize: 9,
-                        letterSpacing: 1,
-                      }}
-                      className="text-mono-secondary"
-                    >
-                      {isFastest ? "FASTEST" : "SLOWEST"}
-                    </Text>
-                  )}
-                </View>
+      {/* Both panels stay mounted so a running stopwatch or timer keeps
+          counting while the other tab is on screen. */}
+      <View
+        className="mt-3 flex-1"
+        style={{ display: activeTab === "stopwatch" ? "flex" : "none" }}
+      >
+        <StopwatchPanel />
+      </View>
 
-                <View className="items-end">
-                  <Text
-                    style={{
-                      fontFamily: "Inter_700Bold",
-                      fontSize: 9,
-                      letterSpacing: 1,
-                    }}
-                    className="text-mono-secondary"
-                  >
-                    TOTAL
-                  </Text>
-                  <Text
-                    style={{
-                      fontFamily: "Inter_700Bold",
-                      fontSize: 15,
-                      fontVariant: ["tabular-nums"],
-                    }}
-                    className="text-mono-primary"
-                  >
-                    {formatFull(split.totalMs)}
-                  </Text>
-                </View>
-              </View>
-            );
-          })}
-        </ScrollView>
-      )}
+      <View
+        className="mt-3 flex-1"
+        style={{ display: activeTab === "timer" ? "flex" : "none" }}
+      >
+        <TimerPanel />
+      </View>
     </View>
   );
 };

--- a/src/screens/timers/StopwatchPanel.tsx
+++ b/src/screens/timers/StopwatchPanel.tsx
@@ -1,0 +1,313 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Pressable, ScrollView, Text, View } from "react-native";
+
+import { formatClock, formatFull, pad } from "./clock";
+
+type Split = {
+  index: number;
+  /** Elapsed time on the stopwatch when the split was taken. */
+  totalMs: number;
+  /** Time since the previous split. */
+  lapMs: number;
+};
+
+export const StopwatchPanel = () => {
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+  const [splits, setSplits] = useState<Split[]>([]);
+
+  // Wall-clock anchors so the timer stays accurate even if the interval drifts.
+  const startedAtRef = useRef(0);
+  const accumulatedRef = useRef(0);
+
+  useEffect(() => {
+    if (!isRunning) {
+      return;
+    }
+
+    const tick = () => {
+      setElapsedMs(accumulatedRef.current + (Date.now() - startedAtRef.current));
+    };
+
+    tick();
+    const interval = setInterval(tick, 50);
+
+    return () => clearInterval(interval);
+  }, [isRunning]);
+
+  const handleStartStop = () => {
+    if (isRunning) {
+      accumulatedRef.current += Date.now() - startedAtRef.current;
+      setElapsedMs(accumulatedRef.current);
+      setIsRunning(false);
+      return;
+    }
+
+    startedAtRef.current = Date.now();
+    setIsRunning(true);
+  };
+
+  const handleSplit = () => {
+    const totalMs = isRunning
+      ? accumulatedRef.current + (Date.now() - startedAtRef.current)
+      : elapsedMs;
+    const previousTotal = splits.length > 0 ? splits[0].totalMs : 0;
+
+    setSplits((current) => [
+      {
+        index: current.length + 1,
+        totalMs,
+        lapMs: totalMs - previousTotal,
+      },
+      ...current,
+    ]);
+  };
+
+  const handleReset = () => {
+    accumulatedRef.current = 0;
+    startedAtRef.current = 0;
+    setIsRunning(false);
+    setElapsedMs(0);
+    setSplits([]);
+  };
+
+  const display = useMemo(() => formatClock(elapsedMs), [elapsedMs]);
+
+  const canSplit = isRunning || elapsedMs > 0;
+  const canReset = !isRunning && (elapsedMs > 0 || splits.length > 0);
+
+  const fastestSplit = useMemo(() => {
+    if (splits.length < 2) {
+      return null;
+    }
+    return splits.reduce((best, split) =>
+      split.lapMs < best.lapMs ? split : best,
+    );
+  }, [splits]);
+
+  const slowestSplit = useMemo(() => {
+    if (splits.length < 2) {
+      return null;
+    }
+    return splits.reduce((worst, split) =>
+      split.lapMs > worst.lapMs ? split : worst,
+    );
+  }, [splits]);
+
+  return (
+    <View className="flex-1">
+      {/* Stopwatch readout */}
+      <View className="rounded-sm bg-mono-surface px-4 py-6">
+        <Text
+          style={{
+            fontFamily: "Inter_700Bold",
+            fontSize: 11,
+            letterSpacing: 0.8,
+          }}
+          className="text-mono-secondary"
+        >
+          STOPWATCH
+        </Text>
+
+        <View className="mt-1 flex-row items-baseline">
+          <Text
+            style={{
+              fontFamily: "Inter_900Black",
+              fontSize: 64,
+              letterSpacing: -2.5,
+              fontVariant: ["tabular-nums"],
+            }}
+            className="text-mono-primary"
+          >
+            {display.clock}
+          </Text>
+          <Text
+            style={{
+              fontFamily: "Inter_800ExtraBold",
+              fontSize: 28,
+              letterSpacing: -0.8,
+              fontVariant: ["tabular-nums"],
+            }}
+            className="ml-1 text-mono-secondary"
+          >
+            .{display.centiseconds}
+          </Text>
+        </View>
+
+        <Text
+          style={{
+            fontFamily: "Inter_700Bold",
+            fontSize: 10,
+            letterSpacing: 1.2,
+          }}
+          className="text-mono-secondary"
+        >
+          {isRunning ? "RUNNING" : elapsedMs > 0 ? "PAUSED" : "READY"}
+        </Text>
+      </View>
+
+      {/* Controls */}
+      <View className="mt-3 flex-row gap-3">
+        <Pressable
+          onPress={handleStartStop}
+          className={`flex-1 items-center rounded-sm py-4 ${
+            isRunning ? "bg-mono-primaryContainer" : "bg-mono-primary"
+          }`}
+        >
+          <Text
+            style={{
+              fontFamily: "Inter_700Bold",
+              fontSize: 12,
+              letterSpacing: 1.2,
+            }}
+            className="text-mono-background"
+          >
+            {isRunning ? "STOP" : elapsedMs > 0 ? "RESUME" : "START"}
+          </Text>
+        </Pressable>
+
+        <Pressable
+          onPress={handleSplit}
+          disabled={!canSplit}
+          className={`flex-1 items-center rounded-sm py-4 ${
+            canSplit ? "bg-mono-surfaceContainer" : "bg-mono-surface"
+          }`}
+        >
+          <Text
+            style={{
+              fontFamily: "Inter_700Bold",
+              fontSize: 12,
+              letterSpacing: 1.2,
+            }}
+            className={canSplit ? "text-mono-primary" : "text-mono-secondary"}
+          >
+            SPLIT
+          </Text>
+        </Pressable>
+
+        <Pressable
+          onPress={handleReset}
+          disabled={!canReset}
+          className={`flex-1 items-center rounded-sm py-4 ${
+            canReset ? "bg-mono-surfaceContainer" : "bg-mono-surface"
+          }`}
+        >
+          <Text
+            style={{
+              fontFamily: "Inter_700Bold",
+              fontSize: 12,
+              letterSpacing: 1.2,
+            }}
+            className={canReset ? "text-mono-primary" : "text-mono-secondary"}
+          >
+            RESET
+          </Text>
+        </Pressable>
+      </View>
+
+      {/* Splits */}
+      <Text
+        style={{
+          fontFamily: "Inter_700Bold",
+          fontSize: 11,
+          letterSpacing: 0.8,
+        }}
+        className="mt-6 text-mono-secondary"
+      >
+        SPLITS ({splits.length})
+      </Text>
+
+      {splits.length === 0 ? (
+        <View className="mt-3 rounded-sm bg-mono-surface px-4 py-6">
+          <Text
+            style={{ fontFamily: "Inter_500Medium", fontSize: 13 }}
+            className="text-mono-secondary"
+          >
+            Start the stopwatch and tap SPLIT to record a lap. Each split stores
+            the lap time and the total elapsed time.
+          </Text>
+        </View>
+      ) : (
+        <ScrollView
+          className="mt-3"
+          contentContainerStyle={{ paddingBottom: 24, gap: 2 }}
+          showsVerticalScrollIndicator={false}
+        >
+          {splits.map((split) => {
+            const isFastest = fastestSplit?.index === split.index;
+            const isSlowest = slowestSplit?.index === split.index;
+
+            return (
+              <View
+                key={split.index}
+                className={`flex-row items-center rounded-sm px-4 py-3 ${
+                  isFastest ? "bg-mono-surfaceContainer" : "bg-mono-surface"
+                }`}
+              >
+                <Text
+                  style={{
+                    fontFamily: "Inter_700Bold",
+                    fontSize: 11,
+                    letterSpacing: 0.6,
+                  }}
+                  className="w-10 text-mono-secondary"
+                >
+                  {pad(split.index)}
+                </Text>
+
+                <View className="flex-1">
+                  <Text
+                    style={{
+                      fontFamily: "Inter_900Black",
+                      fontSize: 22,
+                      letterSpacing: -0.5,
+                      fontVariant: ["tabular-nums"],
+                    }}
+                    className="text-mono-primary"
+                  >
+                    {formatFull(split.lapMs)}
+                  </Text>
+                  {(isFastest || isSlowest) && (
+                    <Text
+                      style={{
+                        fontFamily: "Inter_700Bold",
+                        fontSize: 9,
+                        letterSpacing: 1,
+                      }}
+                      className="text-mono-secondary"
+                    >
+                      {isFastest ? "FASTEST" : "SLOWEST"}
+                    </Text>
+                  )}
+                </View>
+
+                <View className="items-end">
+                  <Text
+                    style={{
+                      fontFamily: "Inter_700Bold",
+                      fontSize: 9,
+                      letterSpacing: 1,
+                    }}
+                    className="text-mono-secondary"
+                  >
+                    TOTAL
+                  </Text>
+                  <Text
+                    style={{
+                      fontFamily: "Inter_700Bold",
+                      fontSize: 15,
+                      fontVariant: ["tabular-nums"],
+                    }}
+                    className="text-mono-primary"
+                  >
+                    {formatFull(split.totalMs)}
+                  </Text>
+                </View>
+              </View>
+            );
+          })}
+        </ScrollView>
+      )}
+    </View>
+  );
+};

--- a/src/screens/timers/TimerPanel.tsx
+++ b/src/screens/timers/TimerPanel.tsx
@@ -1,0 +1,370 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Keyboard,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  Vibration,
+  View,
+} from "react-native";
+
+import { parseDurationToSeconds } from "../../lib/duration";
+import { monoColors } from "../../theme/mono";
+import { formatClock } from "./clock";
+
+const MINUTE_MS = 60_000;
+
+const PRESET_MINUTES = [1, 2, 3, 4, 5, 8, 10, 12, 15, 20];
+
+const DEFAULT_DURATION_MS = 3 * MINUTE_MS;
+
+/**
+ * Parses the custom duration field. A bare number is read as minutes (the
+ * natural unit for a gym timer); anything with a colon falls through to the
+ * shared mm:ss / h:mm:ss parser.
+ */
+const parseTimerInput = (raw: string): number | null => {
+  const value = raw.trim();
+  if (!value) {
+    return null;
+  }
+
+  if (!value.includes(":")) {
+    const minutes = Number(value);
+    if (!Number.isFinite(minutes) || minutes <= 0) {
+      return null;
+    }
+    return Math.round(minutes * MINUTE_MS);
+  }
+
+  const seconds = parseDurationToSeconds(value);
+  return seconds === null ? null : Math.round(seconds * 1000);
+};
+
+const formatPreset = (minutes: number) => `${minutes} MIN`;
+
+// Vibration is unavailable on web, so both calls are no-ops there.
+const buzz = () => {
+  if (Platform.OS !== "web") {
+    Vibration.vibrate([0, 400, 200, 400, 200, 600]);
+  }
+};
+
+const stopBuzz = () => {
+  if (Platform.OS !== "web") {
+    Vibration.cancel();
+  }
+};
+
+export const TimerPanel = () => {
+  const [durationMs, setDurationMs] = useState(DEFAULT_DURATION_MS);
+  const [remainingMs, setRemainingMs] = useState(DEFAULT_DURATION_MS);
+  const [isRunning, setIsRunning] = useState(false);
+  const [hasFinished, setHasFinished] = useState(false);
+  const [customValue, setCustomValue] = useState("");
+
+  // Wall-clock anchor so the countdown stays accurate even if the interval drifts.
+  const endsAtRef = useRef(0);
+
+  useEffect(() => {
+    if (!isRunning) {
+      return;
+    }
+
+    const tick = () => {
+      const left = endsAtRef.current - Date.now();
+
+      if (left <= 0) {
+        setRemainingMs(0);
+        setIsRunning(false);
+        setHasFinished(true);
+        buzz();
+        return;
+      }
+
+      setRemainingMs(left);
+    };
+
+    tick();
+    const interval = setInterval(tick, 50);
+
+    return () => clearInterval(interval);
+  }, [isRunning]);
+
+  const applyDuration = (nextDurationMs: number) => {
+    setDurationMs(nextDurationMs);
+    setRemainingMs(nextDurationMs);
+    setIsRunning(false);
+    setHasFinished(false);
+    stopBuzz();
+  };
+
+  const handleStartStop = () => {
+    if (isRunning) {
+      setRemainingMs(endsAtRef.current - Date.now());
+      setIsRunning(false);
+      return;
+    }
+
+    // Starting after the timer has run out replays the whole duration.
+    const startFrom = remainingMs > 0 ? remainingMs : durationMs;
+    setRemainingMs(startFrom);
+    setHasFinished(false);
+    stopBuzz();
+    endsAtRef.current = Date.now() + startFrom;
+    setIsRunning(true);
+  };
+
+  const handleReset = () => {
+    setIsRunning(false);
+    setHasFinished(false);
+    setRemainingMs(durationMs);
+    stopBuzz();
+  };
+
+  const handleApplyCustom = () => {
+    const parsed = parseTimerInput(customValue);
+    if (parsed === null) {
+      return;
+    }
+
+    applyDuration(parsed);
+    setCustomValue("");
+    Keyboard.dismiss();
+  };
+
+  const display = useMemo(() => formatClock(remainingMs), [remainingMs]);
+
+  const customIsValid = parseTimerInput(customValue) !== null;
+  const canReset = !isRunning && remainingMs !== durationMs;
+  const isIdle = !isRunning && !hasFinished && remainingMs === durationMs;
+
+  const progress = durationMs > 0 ? 1 - remainingMs / durationMs : 0;
+  const progressPercent: `${number}%` = `${Math.min(
+    100,
+    Math.max(0, progress * 100),
+  )}%`;
+
+  const status = isRunning
+    ? "COUNTING DOWN"
+    : hasFinished
+      ? "TIME"
+      : isIdle
+        ? "READY"
+        : "PAUSED";
+
+  return (
+    <View className="flex-1">
+      {/* Countdown readout */}
+      <View
+        className={`rounded-sm px-4 py-6 ${
+          hasFinished ? "bg-mono-surfaceContainer" : "bg-mono-surface"
+        }`}
+      >
+        <Text
+          style={{
+            fontFamily: "Inter_700Bold",
+            fontSize: 11,
+            letterSpacing: 0.8,
+          }}
+          className="text-mono-secondary"
+        >
+          TIMER
+        </Text>
+
+        <View className="mt-1 flex-row items-baseline">
+          <Text
+            style={{
+              fontFamily: "Inter_900Black",
+              fontSize: 64,
+              letterSpacing: -2.5,
+              fontVariant: ["tabular-nums"],
+            }}
+            className="text-mono-primary"
+          >
+            {display.clock}
+          </Text>
+          <Text
+            style={{
+              fontFamily: "Inter_800ExtraBold",
+              fontSize: 28,
+              letterSpacing: -0.8,
+              fontVariant: ["tabular-nums"],
+            }}
+            className="ml-1 text-mono-secondary"
+          >
+            .{display.centiseconds}
+          </Text>
+        </View>
+
+        <Text
+          style={{
+            fontFamily: "Inter_700Bold",
+            fontSize: 10,
+            letterSpacing: 1.2,
+          }}
+          className="text-mono-secondary"
+        >
+          {status}
+        </Text>
+
+        {/* Progress — a background shift rather than a bordered bar. */}
+        <View className="mt-4 h-1 w-full bg-mono-surfaceDim">
+          <View
+            className="h-1 bg-mono-primary"
+            style={{ width: progressPercent }}
+          />
+        </View>
+      </View>
+
+      {/* Controls */}
+      <View className="mt-3 flex-row gap-3">
+        <Pressable
+          onPress={handleStartStop}
+          className={`flex-1 items-center rounded-sm py-4 ${
+            isRunning ? "bg-mono-primaryContainer" : "bg-mono-primary"
+          }`}
+        >
+          <Text
+            style={{
+              fontFamily: "Inter_700Bold",
+              fontSize: 12,
+              letterSpacing: 1.2,
+            }}
+            className="text-mono-background"
+          >
+            {isRunning
+              ? "PAUSE"
+              : hasFinished
+                ? "RESTART"
+                : isIdle
+                  ? "START"
+                  : "RESUME"}
+          </Text>
+        </Pressable>
+
+        <Pressable
+          onPress={handleReset}
+          disabled={!canReset}
+          className={`flex-1 items-center rounded-sm py-4 ${
+            canReset ? "bg-mono-surfaceContainer" : "bg-mono-surface"
+          }`}
+        >
+          <Text
+            style={{
+              fontFamily: "Inter_700Bold",
+              fontSize: 12,
+              letterSpacing: 1.2,
+            }}
+            className={canReset ? "text-mono-primary" : "text-mono-secondary"}
+          >
+            RESET
+          </Text>
+        </Pressable>
+      </View>
+
+      <ScrollView
+        className="mt-6"
+        contentContainerStyle={{ paddingBottom: 24 }}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <Text
+          style={{
+            fontFamily: "Inter_700Bold",
+            fontSize: 11,
+            letterSpacing: 0.8,
+          }}
+          className="text-mono-secondary"
+        >
+          LENGTH
+        </Text>
+
+        <View className="mt-3 flex-row flex-wrap gap-2">
+          {PRESET_MINUTES.map((minutes) => {
+            const presetMs = minutes * MINUTE_MS;
+            const isSelected = durationMs === presetMs;
+
+            return (
+              <Pressable
+                key={minutes}
+                onPress={() => applyDuration(presetMs)}
+                className={`rounded-sm px-4 py-3 ${
+                  isSelected ? "bg-mono-primary" : "bg-mono-surfaceContainer"
+                }`}
+              >
+                <Text
+                  style={{
+                    fontFamily: "Inter_700Bold",
+                    fontSize: 12,
+                    letterSpacing: 0.8,
+                  }}
+                  className={
+                    isSelected ? "text-mono-background" : "text-mono-primary"
+                  }
+                >
+                  {formatPreset(minutes)}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        <Text
+          style={{
+            fontFamily: "Inter_700Bold",
+            fontSize: 11,
+            letterSpacing: 0.8,
+          }}
+          className="mt-6 text-mono-secondary"
+        >
+          CUSTOM
+        </Text>
+
+        <View className="mt-3 flex-row gap-3">
+          <TextInput
+            value={customValue}
+            onChangeText={setCustomValue}
+            onSubmitEditing={handleApplyCustom}
+            placeholder="7 or 7:30"
+            placeholderTextColor={monoColors.secondary}
+            keyboardType="numbers-and-punctuation"
+            returnKeyType="done"
+            style={{ fontFamily: "Inter_500Medium", fontSize: 14 }}
+            className="flex-1 rounded-sm bg-mono-surfaceContainer px-4 py-3 text-mono-primary"
+          />
+
+          <Pressable
+            onPress={handleApplyCustom}
+            disabled={!customIsValid}
+            className={`items-center justify-center rounded-sm px-6 ${
+              customIsValid ? "bg-mono-primary" : "bg-mono-surface"
+            }`}
+          >
+            <Text
+              style={{
+                fontFamily: "Inter_700Bold",
+                fontSize: 12,
+                letterSpacing: 1.2,
+              }}
+              className={
+                customIsValid ? "text-mono-background" : "text-mono-secondary"
+              }
+            >
+              SET
+            </Text>
+          </Pressable>
+        </View>
+
+        <Text
+          style={{ fontFamily: "Inter_500Medium", fontSize: 12 }}
+          className="mt-2 text-mono-secondary"
+        >
+          A plain number is read as minutes. Use mm:ss for anything finer.
+        </Text>
+      </ScrollView>
+    </View>
+  );
+};

--- a/src/screens/timers/clock.ts
+++ b/src/screens/timers/clock.ts
@@ -1,0 +1,23 @@
+// Millisecond formatting for the live readouts on the Timers screen.
+// (src/lib/duration.ts covers the second-based durations stored on entries.)
+
+export const pad = (value: number, length = 2) =>
+  String(value).padStart(length, "0");
+
+export const formatClock = (ms: number) => {
+  const safeMs = Math.max(0, ms);
+  const totalSeconds = Math.floor(safeMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  const centiseconds = Math.floor((safeMs % 1000) / 10);
+
+  return {
+    clock: `${pad(minutes)}:${pad(seconds)}`,
+    centiseconds: pad(centiseconds),
+  };
+};
+
+export const formatFull = (ms: number) => {
+  const { clock, centiseconds } = formatClock(ms);
+  return `${clock}.${centiseconds}`;
+};


### PR DESCRIPTION
The Timers tab now switches between STOPWATCH and TIMER. The countdown offers 1-20 minute presets plus a custom field, where a bare number reads as minutes — the natural unit for a gym timer — and anything with a colon falls through to the shared mm:ss parser in lib/duration.

Like the stopwatch, the countdown anchors to a wall-clock deadline rather than accumulating interval ticks, so it stays accurate when the 50ms interval drifts. Finishing buzzes a vibration pattern; both vibration calls no-op on web, where the API is unavailable.

TimersScreen shrinks to the tab switcher, with the existing stopwatch moved out to timers/StopwatchPanel.tsx and its millisecond formatting to timers/clock.ts, shared by both panels.