### PR TITLE
fix: surface failed Supabase writes instead of silently caching

### DIFF
--- a/src/components/AddLiftEntryModal.tsx
+++ b/src/components/AddLiftEntryModal.tsx
@@ -130,6 +130,12 @@ export const AddLiftEntryModal = ({
         splitSeconds,
       });
       resetForm();
+    } catch (submitError) {
+      setFormError(
+        submitError instanceof Error
+          ? submitError.message
+          : "Could not save this entry.",
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/src/lib/trainingRepository.ts
+++ b/src/lib/trainingRepository.ts
@@ -52,6 +52,26 @@ const mapLiftRow = (row: any): LiftEntry => ({
   splitSeconds: mapSplitSeconds(row.split_seconds),
 });
 
+// PostgREST reports a column the app writes but the table lacks as PGRST204.
+// That means the database is behind docs/supabase_schema.sql, so say so rather
+// than leaking the raw schema-cache wording.
+const describeWriteFailure = (context: string, error: any): Error => {
+  console.warn(`[trainingRepository] ${context}:`, error);
+
+  if (error?.code === "PGRST204") {
+    return new Error(
+      `${context}. Your Supabase tables are missing a column the app writes — run docs/supabase_schema.sql in the SQL editor.`,
+    );
+  }
+
+  const message =
+    typeof error?.message === "string" && error.message
+      ? error.message
+      : "Supabase rejected the request.";
+
+  return new Error(`${context}. ${message}`);
+};
+
 const readCache = async (): Promise<CachePayload | null> => {
   const raw = await AsyncStorage.getItem(CACHE_KEY);
   if (!raw) {
@@ -197,7 +217,9 @@ export const addLiftEntry = async (input: AddLiftEntryInput): Promise<void> => {
 
       return;
     } catch (error) {
-      console.warn("[trainingRepository] addLiftEntry falling back to cache:", error);
+      // Reads prefer Supabase, so a cache-only write would be silently wiped by
+      // the next successful fetch. Surface the failure instead of hiding it.
+      throw describeWriteFailure("Could not save this entry", error);
     }
   }
 
@@ -247,7 +269,7 @@ export const updateLiftEntry = async (
 
       return;
     } catch (error) {
-      console.warn("[trainingRepository] updateLiftEntry falling back to cache:", error);
+      throw describeWriteFailure("Could not update this entry", error);
     }
   }
 
@@ -283,7 +305,7 @@ export const deleteLiftEntry = async (id: string): Promise<void> => {
 
       return;
     } catch (error) {
-      console.warn("[trainingRepository] deleteLiftEntry falling back to cache:", error);
+      throw describeWriteFailure("Could not delete this entry", error);
     }
   }
 
@@ -318,7 +340,7 @@ export const deleteExercise = async (id: string): Promise<void> => {
 
       return;
     } catch (error) {
-      console.warn("[trainingRepository] deleteExercise falling back to cache:", error);
+      throw describeWriteFailure("Could not delete this exercise", error);
     }
   }
 

--- a/src/screens/ExerciseDetailScreen.tsx
+++ b/src/screens/ExerciseDetailScreen.tsx
@@ -34,6 +34,10 @@ const formatDate = (iso: string): string => {
   });
 };
 
+const describeError = (error: unknown): string => {
+  return error instanceof Error ? error.message : "Something went wrong.";
+};
+
 export const ExerciseDetailScreen = ({ route, navigation }: Props) => {
   const { exerciseId, exerciseName } = route.params;
   const {
@@ -163,6 +167,12 @@ export const ExerciseDetailScreen = ({ route, navigation }: Props) => {
       });
       setIsEditModalOpen(false);
       setSelectedEntry(null);
+    } catch (submitError) {
+      setEditError(
+        submitError instanceof Error
+          ? submitError.message
+          : "Could not update this entry.",
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -189,8 +199,12 @@ export const ExerciseDetailScreen = ({ route, navigation }: Props) => {
           text: "Delete",
           style: "destructive",
           onPress: async () => {
-            await deleteEntry(selectedEntry.id);
-            setSelectedEntry(null);
+            try {
+              await deleteEntry(selectedEntry.id);
+              setSelectedEntry(null);
+            } catch (deleteError) {
+              Alert.alert("Delete Failed", describeError(deleteError));
+            }
           },
         },
       ],
@@ -207,8 +221,12 @@ export const ExerciseDetailScreen = ({ route, navigation }: Props) => {
           text: "Delete All",
           style: "destructive",
           onPress: async () => {
-            await deleteExerciseById(exerciseId);
-            navigation.goBack();
+            try {
+              await deleteExerciseById(exerciseId);
+              navigation.goBack();
+            } catch (deleteError) {
+              Alert.alert("Delete Failed", describeError(deleteError));
+            }
           },
         },
       ],


### PR DESCRIPTION
Reads prefer Supabase, so a write that failed remotely and fell back to AsyncStorage was wiped by the next successful fetch. Entries appeared to save, then showed as "--" once the cache was overwritten. Writes now throw when Supabase is configured, and the add/edit sheets and delete alerts show the error. PGRST204 is reported as a schema drift against docs/supabase_schema.sql.